### PR TITLE
RED-3939: Initial aviary.yaml

### DIFF
--- a/aviary.yaml
+++ b/aviary.yaml
@@ -1,0 +1,9 @@
+version: 1
+
+raven_monitored_keywords:
+  \.exec\(:
+    languages:
+      - ts
+      - js
+    reason: RCE risk, prefer use of `execFile`
+    


### PR DESCRIPTION
This file provides default configuration overrides for Aviary. In this case, this added config will cause Aviary to flag on PRs that include calls to `.exec(` in TypeScript or JavaScript files, and require a security review on them.