### PR TITLE
Release vs-code-format-on-save 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "over-react-format-on-save",
 	"displayName": "OverReact Format on Save",
 	"description": "A Dart project formatting tool that enables formatting on file save. Attempts to use OverReact Format but defaults to dartfmt.",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"publisher": "Workiva",
 	"repository": "https://github.com/Workiva/vs-code-format-on-save/",
 	"engines": {


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FEDX-584 : Migrate vs-code-format-on-save to GHA](https://github.com/Workiva/vs-code-format-on-save/pull/26)


Requested by: @robbecker-wf

@Workiva/release-management-p

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/vs-code-format-on-save/compare/1.0.2...Workiva:release_vs-code-format-on-save_1.0.3
Diff Between Last Tag and New Tag: https://github.com/Workiva/vs-code-format-on-save/compare/1.0.2...1.0.3

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/4654862381088768/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/4654862381088768/?repo_name=Workiva%2Fvs-code-format-on-save&pull_number=27)