### PR TITLE
Finalize GHA migration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,8 @@ on:
   release:
 
 permissions:
-  contents: read
+  pull-requests: write
+  contents: write
   id-token: write
 
 jobs:
@@ -78,3 +79,9 @@ jobs:
         with:
           name: vs-code-extension
           path: "*.vsix"
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: ./
+          format: cyclonedx-json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,0 @@
-FROM scratch


### PR DESCRIPTION
# Summary
Finalize the migration to Github Actions for CI while also maintaining dependency tracking for Workiva.

# Changes
- removes Dockerfile
- added Software Bill of Materials (SBOM) generation
- Updated permissions to the ones needed to run SBOM generation

# QA
- GHA CI passes
- Workiva Build will fail since Dockerfile is removed, but this is intended and ok to merge with the failure
- the cyclone.dx file is included as an artifact on the github job summary